### PR TITLE
Make setPlayerState return 204 in spec

### DIFF
--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -71,7 +71,7 @@ paths:
         in: query
         type: number
       responses:
-        200:
+        204:
           description: Success
 
   /player/play:


### PR DESCRIPTION
I haven't tested this in a development environment, but bravado stopped complaining when I changed the spec like this. The alternative fix, of course, would be to change it to actually return 200. Fixes #124.

Thanks for the component, really excited to use it!