### PR TITLE
Add git dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You could also build debug version by switching `--release` to `--debug`.
 #### foobar2000
 You'll need to install Visual Studio (currently tested with VS2015 Community).
 The following programs should be installed in addition:
-`node` runtime, `yarn` package manager, `cmake` build system, `7z` archiver and `curl` HTTP client.
+`git` version control system, `node` runtime, `yarn` package manager, `cmake` build system, `7z` archiver and `curl` HTTP client.
 These programs should be available in `PATH`.
 
 Open Visual Studio command prompt, navigate to project directory, run the following command:


### PR DESCRIPTION
Git is required on PATH when building for foobar2000.