### PR TITLE
apply-patches.cmd: propagate exit code on error

### DIFF
--- a/server/extlibs/apply-patches.cmd
+++ b/server/extlibs/apply-patches.cmd
@@ -3,9 +3,13 @@
 @set src_dir=%~dp0%1
 
 @call :apply_patches "%src_dir%\patches"
+if %errorlevel% neq 0 goto :error
 @call :apply_patches "%src_dir%\patches.windows"
+if %errorlevel% neq 0 goto :error
 @call :copy_files "%src_dir%\files"
+if %errorlevel% neq 0 goto :error
 @call :copy_files "%src_dir%\files.windows"
+if %errorlevel% neq 0 goto :error
 
 @goto :end
 
@@ -28,6 +32,9 @@
 :usage
 @echo usage: %~nx0 target
 @echo.
-@cmd /c exit 1
+@exit /b 1
+
+:error
+@exit /b %errorlevel%
 
 :end


### PR DESCRIPTION
The `%errorlevel%` variable does not automatically set the exit code of the batch script. This has to be done with the `exit` command. I am not aware of an eqivalent of `set -e` in shell scripts so the modified batch script includes explicit checks.

Note that manual tests should be performed using `cmd /c apply-patches.cmd ...` rather than `apply-patches ...`. This ensures that the batch script executes in a separate process.