### PR TITLE
Added meta tags to enable web app mode for iOS and Android

### DIFF
--- a/js/webui/src/index.html
+++ b/js/webui/src/index.html
@@ -1,8 +1,10 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <title>Loading...</title>
 </head>
 <body>


### PR DESCRIPTION
I added two HTML `<meta>` tags that enable mobile app mode on iOS and Android. I confirmed that it works on my Android phone: when I create a home screen shortcut, it now opens Chrome in a fullscreen mode without the address bar. Looks nice!