### PR TITLE
WIP: Play directly from the file browser

### DIFF
--- a/js/client/src/player_client.js
+++ b/js/client/src/player_client.js
@@ -205,7 +205,34 @@ export default class PlayerClient
                 `api/playlists/${options.playlist}/items/move`, data);
         }
     }
-
+    
+    getBeefwebPlaylist() {
+      var e = "beefweb";
+      var p = this.playlists.find(t=>t.title === e)
+      if (p) {
+        return p
+      } else {
+        this.client.addPlaylist({
+            title: e
+        })
+        this.emit("playlistsChange")
+        // todo: fix this
+        return this.playlists.find(t=>t.title === e)
+      }
+    }
+    directPlay(e) {
+      var p = this.getBeefwebPlaylist();
+      if (p) {
+        this.client.addPlaylistItems(p.id, e).then( x => {
+            this.client.getPlaylists().then( r => {
+              p = r.find(t=>t.id == p.id)
+              this.client.play(p.id, p.itemCount - 1)
+            })
+        })
+        //this.client.next();
+      }
+    }
+    
     getFileSystemRoots()
     {
         return this.get('api/browser/roots');

--- a/js/webui/src/file_browser.js
+++ b/js/webui/src/file_browser.js
@@ -68,8 +68,8 @@ class FileBrowser extends React.PureComponent
     {
         const { playlistModel, fileBrowserModel, notificationModel } = this.props;
         const itemPath = fileBrowserModel.entries[index].path;
-        playlistModel.addItems([itemPath]);
-        playlistModel.client.next();
+        playlistModel.directPlay([itemPath]);
+        //playlistModel.addItems([itemPath]);
         //notificationModel.notifyAddItem(itemPath);
     }
 

--- a/js/webui/src/file_browser.js
+++ b/js/webui/src/file_browser.js
@@ -69,7 +69,8 @@ class FileBrowser extends React.PureComponent
         const { playlistModel, fileBrowserModel, notificationModel } = this.props;
         const itemPath = fileBrowserModel.entries[index].path;
         playlistModel.addItems([itemPath]);
-        notificationModel.notifyAddItem(itemPath);
+        playlistModel.client.next();
+        //notificationModel.notifyAddItem(itemPath);
     }
 
     render()


### PR DESCRIPTION
I'm weird and primarily organize my music into directories.

But thanks to your impeccably architectured react app, I was able to quickly come up with something to play the selected item from the file browser view. Thanks!

I'm creating this pull request just in case it'll be helpful to other weird folks.

I plan(tm) to polish this up and make it configurable in settings etc, but no promises since this meets my needs entirely and not sure how much more I'll spend on this. Feel free to close this if I'm unresponsive.

Note: edits have been done directly on the prettified bundle.js from the foobar v0.4 release and reapplied onto master (since no local dev env 😄)
