### PR TITLE
Improve UI layout for narrow screens

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,5 +1,8 @@
 # Changes in v0.8 (not released)
-
+- Use imperative present tense for change log entries
+- Adjust screen size breakpoints (approximately 640px for medium size and 960px for large size)
+- Convert view switcher to menu on small size screens
+- Display album column by default on medium size screens
 
 # Changes in v0.7 (released 2023-02-26)
 - API specification is converted to OpenAPI v3

--- a/js/webui/src/app.js
+++ b/js/webui/src/app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { PanelHeader } from './elements.js'
-import ControlBar from './control_bar.js'
+import { ControlBar } from './control_bar.js'
 import PlaylistSwitcher from './playlist_switcher.js'
 import PlaylistMenu from './playlist_menu.js'
 import PlaylistContent from './playlist_content.js'

--- a/js/webui/src/columns.js
+++ b/js/webui/src/columns.js
@@ -1,9 +1,4 @@
 export const Visibility = Object.freeze({
-    never: Object.freeze({
-        small: false,
-        medium: false,
-        large: false,
-    }),
     always: Object.freeze({
         small: true,
         medium: true,
@@ -18,7 +13,12 @@ export const Visibility = Object.freeze({
         small: false,
         medium: false,
         large: true,
-    })
+    }),
+    never: Object.freeze({
+        small: false,
+        medium: false,
+        large: false,
+    }),
 });
 
 const defaultOptions = Object.freeze({

--- a/js/webui/src/columns.js
+++ b/js/webui/src/columns.js
@@ -9,6 +9,11 @@ export const Visibility = Object.freeze({
         medium: true,
         large: true
     }),
+    mediumAndLarge: Object.freeze({
+        small: false,
+        medium: true,
+        large: true
+    }),
     largeOnly: Object.freeze({
         small: false,
         medium: false,
@@ -43,7 +48,7 @@ function column(title, expression, opts = null)
 
 export const allColumns = [
     playlistColumn('Artist', '%artist%', Visibility.always),
-    playlistColumn('Album', '%album%', Visibility.largeOnly),
+    playlistColumn('Album', '%album%', Visibility.mediumAndLarge),
     playlistColumn('Track No', '%track%', Visibility.largeOnly),
     playlistColumn('Title', '%title%', Visibility.always),
     playlistColumn('Duration', '%length%', Visibility.largeOnly),

--- a/js/webui/src/control_bar.js
+++ b/js/webui/src/control_bar.js
@@ -10,14 +10,14 @@ import PlayerModel from './player_model.js';
 
 export default function ControlBar(props)
 {
-    const { playerModel, navigationModel } = props;
+    const { playerModel } = props;
 
     return (
         <div key='control-bar' className='panel control-bar'>
             <PlaybackControl />
             <PositionControl playerModel={playerModel} />
             <VolumeControl />
-            <ViewSwitcher navigationModel={navigationModel} />
+            <ViewSwitcher />
         </div>
     );
 }

--- a/js/webui/src/control_bar.js
+++ b/js/webui/src/control_bar.js
@@ -1,29 +1,55 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import PlaybackControl from './playback_control.js'
 import PositionControl from './position_control.js'
-import VolumeControl from './volume_control.js'
-import ViewSwitcher from './view_switcher.js'
-import SettingsModel from './settings_model.js';
-import NavigationModel from './navigation_model.js';
-import PlayerModel from './player_model.js';
+import { VolumeControl, VolumeControlButton } from './volume_control.js'
+import { ViewSwitcher, ViewSwitcherButton } from './view_switcher.js'
+import ServiceContext from "./service_context.js";
+import ModelBinding from "./model_binding.js";
+import { MediaSize } from "./settings_model.js";
 
-export default function ControlBar(props)
+class ControlBar_ extends React.PureComponent
 {
-    const { playerModel } = props;
+    constructor(props, context)
+    {
+        super(props, context);
 
-    return (
-        <div key='control-bar' className='panel control-bar'>
-            <PlaybackControl />
-            <PositionControl playerModel={playerModel} />
-            <VolumeControl />
-            <ViewSwitcher />
-        </div>
-    );
+        this.state = this.getStateFromModel();
+    }
+
+    getStateFromModel()
+    {
+        return {
+            inlineMode: this.context.settingsModel.mediaSizeUp(MediaSize.medium)
+        };
+    }
+
+    render()
+    {
+        const { inlineMode } = this.state;
+
+        return (
+            <div key='control-bar' className='panel control-bar'>
+                <PlaybackControl/>
+                <PositionControl playerModel={this.context.playerModel}/>
+                {
+                    inlineMode
+                        ? (
+                            <>
+                                <VolumeControl/>
+                                <ViewSwitcher/>
+                            </>)
+                        : (
+                            <div className='button-bar'>
+                                <VolumeControlButton/>
+                                <ViewSwitcherButton/>
+                            </div>
+                        )
+                }
+            </div>
+        );
+    }
 }
 
-ControlBar.propTypes = {
-    playerModel: PropTypes.instanceOf(PlayerModel).isRequired,
-    settingsModel: PropTypes.instanceOf(SettingsModel).isRequired,
-    navigationModel: PropTypes.instanceOf(NavigationModel).isRequired,
-};
+ControlBar_.contextType = ServiceContext;
+
+export const ControlBar = ModelBinding(ControlBar_, { settingsModel: 'mediaSizeChange' });

--- a/js/webui/src/media_size_controller.js
+++ b/js/webui/src/media_size_controller.js
@@ -4,8 +4,8 @@ import { MediaSize, MediaSizeIndex } from './settings_model.js'
 
 const MediaSizes = Object.freeze({
     small: 0,
-    medium: 31,
-    large: 43,
+    medium: 35,
+    large: 45,
 });
 
 const FontScale = Object.freeze({

--- a/js/webui/src/media_size_controller.js
+++ b/js/webui/src/media_size_controller.js
@@ -4,8 +4,8 @@ import { MediaSize, MediaSizeIndex } from './settings_model.js'
 
 const MediaSizes = Object.freeze({
     small: 0,
-    medium: 35,
-    large: 45,
+    medium: 40, // 640px
+    large: 60, // 960px
 });
 
 const FontScale = Object.freeze({

--- a/js/webui/src/style.less
+++ b/js/webui/src/style.less
@@ -653,27 +653,9 @@ body {
     padding: 0.25rem;
 }
 
-.volume-control,
-.volume-control-full {
+.volume-control {
     display: inline-block;
-}
-
-.volume-control-mini {
-    display: none;
-}
-
-.volume-control-mini .volume-control-panel {
     width: 9rem;
-}
-
-.st-mediasize-small-down {
-    .volume-control-full {
-        display: none;
-    }
-
-    .volume-control-mini {
-        display: inline-block;
-    }
 }
 
 .volume-slider {

--- a/js/webui/src/view_switcher.js
+++ b/js/webui/src/view_switcher.js
@@ -1,53 +1,100 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-import { Button } from './elements.js'
+import { Button, Menu, MenuItem } from './elements.js'
 import urls from './urls.js'
 import ModelBinding from './model_binding.js';
-import NavigationModel, { View } from './navigation_model.js';
+import { View } from './navigation_model.js';
+import ServiceContext from "./service_context.js";
+import { MediaSize } from "./settings_model.js";
+import { DropdownButton } from "./dropdown.js";
+import { bindHandlers } from "./utils.js";
 
 class ViewSwitcher extends React.PureComponent
 {
-    constructor(props)
+    constructor(props, context)
     {
-        super(props);
+        super(props, context);
+
+        bindHandlers(this);
 
         this.state = this.getStateFromModel();
+        this.state.menuOpen = false;
     }
 
     getStateFromModel()
     {
-        const { view } = this.props.navigationModel;
-        return { view };
+        const { navigationModel, settingsModel } = this.context;
+
+        return {
+            view: navigationModel.view,
+            displayInline: settingsModel.mediaSizeUp(MediaSize.medium),
+        };
+    }
+
+    handleMenuRequestOpen(value)
+    {
+        this.setState({ menuOpen: value });
     }
 
     render()
     {
-        const { view } = this.state;
+        const { menuOpen, view, displayInline } = this.state;
+
+        if (displayInline)
+        {
+            return (
+                <div className='view-switcher button-bar'>
+                    <Button
+                        name='list'
+                        href={urls.viewCurrentPlaylist}
+                        active={view === View.playlist}
+                        title='Playlist'/>
+                    <Button
+                        name='folder'
+                        href={urls.browseCurrentPath}
+                        active={view === View.fileBrowser}
+                        title='Files'/>
+                    <Button
+                        name='cog'
+                        href={urls.viewCurrentSettings}
+                        active={view === View.settings}
+                        title='Settings'/>
+                </div>
+            );
+        }
 
         return (
             <div className='view-switcher button-bar'>
-                <Button
-                    name='list'
-                    href={urls.viewCurrentPlaylist}
-                    active={view === View.playlist}
-                    title='View playlists' />
-                <Button
-                    name='folder'
-                    href={urls.browseCurrentPath}
-                    active={view === View.fileBrowser}
-                    title='Browse files' />
-                <Button
-                    name='cog'
-                    href={urls.viewCurrentSettings}
-                    active={view === View.settings}
-                    title='View settings' />
+                <DropdownButton
+                    title='Switch view'
+                    iconName='list'
+                    hideOnContentClick={true}
+                    direction='left'
+                    isOpen={menuOpen}
+                    onRequestOpen={this.handleMenuRequestOpen}>
+                    <Menu>
+                        <MenuItem
+                            href={urls.viewCurrentPlaylist}
+                            checked={view === View.playlist}
+                            title='Playlist'/>
+                        <MenuItem
+                            href={urls.browseCurrentPath}
+                            checked={view === View.fileBrowser}
+                            title='Files'/>
+                        <MenuItem
+                            href={urls.viewCurrentSettings}
+                            checked={view === View.settings}
+                            title='Settings'/>
+                    </Menu>
+                </DropdownButton>
             </div>
         );
     }
 }
 
-ViewSwitcher.propTypes = {
-    navigationModel: PropTypes.instanceOf(NavigationModel).isRequired
-};
+ViewSwitcher.propTypes = {};
+ViewSwitcher.contextType = ServiceContext;
 
-export default ModelBinding(ViewSwitcher, { navigationModel: 'viewChange' });
+export default ModelBinding(ViewSwitcher, {
+    navigationModel: 'viewChange',
+    settingsModel: 'mediaSizeChange'
+});

--- a/js/webui/src/view_switcher.js
+++ b/js/webui/src/view_switcher.js
@@ -4,11 +4,56 @@ import urls from './urls.js'
 import ModelBinding from './model_binding.js';
 import { View } from './navigation_model.js';
 import ServiceContext from "./service_context.js";
-import { MediaSize } from "./settings_model.js";
 import { DropdownButton } from "./dropdown.js";
 import { bindHandlers } from "./utils.js";
 
-class ViewSwitcher extends React.PureComponent
+class ViewSwitcher_ extends React.PureComponent
+{
+    constructor(props, context)
+    {
+        super(props, context);
+
+        this.state = this.getStateFromModel();
+    }
+
+    getStateFromModel()
+    {
+        return {
+            view: this.context.navigationModel.view,
+        };
+    }
+
+    render()
+    {
+        const { view } = this.state;
+
+        return (
+            <div className='view-switcher button-bar'>
+                <Button
+                    name='list'
+                    href={urls.viewCurrentPlaylist}
+                    active={view === View.playlist}
+                    title='Playlist'/>
+                <Button
+                    name='folder'
+                    href={urls.browseCurrentPath}
+                    active={view === View.fileBrowser}
+                    title='Files'/>
+                <Button
+                    name='cog'
+                    href={urls.viewCurrentSettings}
+                    active={view === View.settings}
+                    title='Settings'/>
+            </div>
+        );
+    }
+}
+
+ViewSwitcher_.contextType = ServiceContext;
+
+export const ViewSwitcher = ModelBinding(ViewSwitcher_, { navigationModel: 'viewChange' });
+
+class ViewSwitcherButton_ extends React.PureComponent
 {
     constructor(props, context)
     {
@@ -20,81 +65,49 @@ class ViewSwitcher extends React.PureComponent
         this.state.menuOpen = false;
     }
 
-    getStateFromModel()
-    {
-        const { navigationModel, settingsModel } = this.context;
-
-        return {
-            view: navigationModel.view,
-            displayInline: settingsModel.mediaSizeUp(MediaSize.medium),
-        };
-    }
-
     handleMenuRequestOpen(value)
     {
-        this.setState({ menuOpen: value });
+        this.setState({menuOpen: value});
+    }
+
+    getStateFromModel()
+    {
+        return {
+            view: this.context.navigationModel.view,
+        };
     }
 
     render()
     {
-        const { menuOpen, view, displayInline } = this.state;
-
-        if (displayInline)
-        {
-            return (
-                <div className='view-switcher button-bar'>
-                    <Button
-                        name='list'
-                        href={urls.viewCurrentPlaylist}
-                        active={view === View.playlist}
-                        title='Playlist'/>
-                    <Button
-                        name='folder'
-                        href={urls.browseCurrentPath}
-                        active={view === View.fileBrowser}
-                        title='Files'/>
-                    <Button
-                        name='cog'
-                        href={urls.viewCurrentSettings}
-                        active={view === View.settings}
-                        title='Settings'/>
-                </div>
-            );
-        }
+        const { view, menuOpen } = this.state;
 
         return (
-            <div className='view-switcher button-bar'>
-                <DropdownButton
-                    title='Switch view'
-                    iconName='list'
-                    hideOnContentClick={true}
-                    direction='left'
-                    isOpen={menuOpen}
-                    onRequestOpen={this.handleMenuRequestOpen}>
-                    <Menu>
-                        <MenuItem
-                            href={urls.viewCurrentPlaylist}
-                            checked={view === View.playlist}
-                            title='Playlist'/>
-                        <MenuItem
-                            href={urls.browseCurrentPath}
-                            checked={view === View.fileBrowser}
-                            title='Files'/>
-                        <MenuItem
-                            href={urls.viewCurrentSettings}
-                            checked={view === View.settings}
-                            title='Settings'/>
-                    </Menu>
-                </DropdownButton>
-            </div>
+            <DropdownButton
+                title='Switch view'
+                iconName='list'
+                hideOnContentClick={true}
+                direction='left'
+                isOpen={menuOpen}
+                onRequestOpen={this.handleMenuRequestOpen}>
+                <Menu>
+                    <MenuItem
+                        href={urls.viewCurrentPlaylist}
+                        checked={view === View.playlist}
+                        title='Playlist'/>
+                    <MenuItem
+                        href={urls.browseCurrentPath}
+                        checked={view === View.fileBrowser}
+                        title='Files'/>
+                    <MenuItem
+                        href={urls.viewCurrentSettings}
+                        checked={view === View.settings}
+                        title='Settings'/>
+                </Menu>
+            </DropdownButton>
         );
     }
 }
 
-ViewSwitcher.propTypes = {};
-ViewSwitcher.contextType = ServiceContext;
+ViewSwitcherButton_.contextType = ServiceContext;
 
-export default ModelBinding(ViewSwitcher, {
-    navigationModel: 'viewChange',
-    settingsModel: 'mediaSizeChange'
-});
+export const ViewSwitcherButton = ModelBinding(ViewSwitcherButton_, { navigationModel: 'viewChange' });

--- a/js/webui/src/volume_control.js
+++ b/js/webui/src/volume_control.js
@@ -5,13 +5,14 @@ import { bindHandlers, dbToLinear, linearToDb } from './utils.js'
 import ModelBinding from './model_binding.js';
 import { DropdownButton } from './dropdown.js';
 import ServiceContext from "./service_context.js";
+import { MediaSize } from "./settings_model.js";
 
 function volumeIcon(isMuted)
 {
     return isMuted ? 'volume-off' : 'volume-high';
 }
 
-class VolumeControlPanelContent extends React.PureComponent
+class VolumeControlContent_ extends React.PureComponent
 {
     constructor(props, context)
     {
@@ -64,7 +65,7 @@ class VolumeControlPanelContent extends React.PureComponent
         const { hintText, min, max, value, isMuted } = this.state;
 
         return (
-            <div className='volume-control-panel'>
+            <div className='volume-control'>
                 <div className='button-bar'>
                     <Button
                         name={volumeIcon(isMuted)}
@@ -83,13 +84,13 @@ class VolumeControlPanelContent extends React.PureComponent
     }
 }
 
-VolumeControlPanelContent.propTypes = {
+VolumeControlContent_.propTypes = {
     onAfterMuteClick: PropTypes.func,
 };
 
-VolumeControlPanelContent.contextType = ServiceContext;
+VolumeControlContent_.contextType = ServiceContext;
 
-const VolumeControlPanel = ModelBinding(VolumeControlPanelContent, { playerModel: 'change' });
+const VolumeControlContent = ModelBinding(VolumeControlContent_, { playerModel: 'change' });
 
 class VolumeControl extends React.PureComponent
 {
@@ -106,8 +107,11 @@ class VolumeControl extends React.PureComponent
 
     getStateFromModel()
     {
+        const { playerModel, settingsModel } = this.context;
+
         return {
-            isMuted: this.context.playerModel.volume.isMuted
+            isMuted: playerModel.volume.isMuted,
+            showFullControl: settingsModel.mediaSizeUp(MediaSize.medium),
         };
     }
 
@@ -123,29 +127,27 @@ class VolumeControl extends React.PureComponent
 
     render()
     {
-        const { playerModel } = this.props;
-        const { isMuted, panelOpen } = this.state;
+        const { playerModel } = this.context;
+        const { isMuted, panelOpen, showFullControl } = this.state;
+
+        if (showFullControl)
+        {
+            return <VolumeControlContent />;
+        }
 
         return (
-            <div className='volume-control'>
-                <div className='volume-control-mini'>
-                    <div className='button-bar'>
-                        <DropdownButton
-                            title='Show volume panel'
-                            iconName={volumeIcon(isMuted)}
-                            hideOnContentClick={false}
-                            direction='center'
-                            isOpen={panelOpen}
-                            onRequestOpen={this.handlePanelRequestOpen}>
-                            <VolumeControlPanel
-                                playerModel={playerModel}
-                                onAfterMuteClick={this.handleMuteClick} />
-                        </DropdownButton>
-                    </div>
-                </div>
-                <div className='volume-control-full'>
-                    <VolumeControlPanel playerModel={playerModel} />
-                </div>
+            <div className='button-bar`'>
+                <DropdownButton
+                    title='Show volume panel'
+                    iconName={volumeIcon(isMuted)}
+                    hideOnContentClick={false}
+                    direction='center'
+                    isOpen={panelOpen}
+                    onRequestOpen={this.handlePanelRequestOpen}>
+                    <VolumeControlContent
+                        playerModel={playerModel}
+                        onAfterMuteClick={this.handleMuteClick}/>
+                </DropdownButton>
             </div>
         );
     }
@@ -154,4 +156,7 @@ class VolumeControl extends React.PureComponent
 VolumeControl.propTypes = {};
 VolumeControl.contextType = ServiceContext;
 
-export default ModelBinding(VolumeControl, { playerModel: 'change' });
+export default ModelBinding(VolumeControl, {
+    playerModel: 'change',
+    settingsModel: 'mediaSizeChange'
+});

--- a/js/webui/src/volume_control.js
+++ b/js/webui/src/volume_control.js
@@ -98,11 +98,10 @@ class VolumeControl extends React.PureComponent
     {
         super(props, context);
 
-        this.state = Object.assign(this.getStateFromModel(), {
-           panelOpen: false
-        });
-
         bindHandlers(this);
+
+        this.state = this.getStateFromModel();
+        this.state.panelOpen = false;
     }
 
     getStateFromModel()
@@ -111,7 +110,7 @@ class VolumeControl extends React.PureComponent
 
         return {
             isMuted: playerModel.volume.isMuted,
-            showFullControl: settingsModel.mediaSizeUp(MediaSize.medium),
+            displayInline: settingsModel.mediaSizeUp(MediaSize.medium),
         };
     }
 
@@ -128,9 +127,9 @@ class VolumeControl extends React.PureComponent
     render()
     {
         const { playerModel } = this.context;
-        const { isMuted, panelOpen, showFullControl } = this.state;
+        const { isMuted, panelOpen, displayInline } = this.state;
 
-        if (showFullControl)
+        if (displayInline)
         {
             return <VolumeControlContent />;
         }

--- a/js/webui/src/volume_control.js
+++ b/js/webui/src/volume_control.js
@@ -1,18 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button} from './elements.js'
+import { Button } from './elements.js'
 import { bindHandlers, dbToLinear, linearToDb } from './utils.js'
 import ModelBinding from './model_binding.js';
 import { DropdownButton } from './dropdown.js';
 import ServiceContext from "./service_context.js";
-import { MediaSize } from "./settings_model.js";
 
 function volumeIcon(isMuted)
 {
     return isMuted ? 'volume-off' : 'volume-high';
 }
 
-class VolumeControlContent_ extends React.PureComponent
+class VolumeControl_ extends React.PureComponent
 {
     constructor(props, context)
     {
@@ -84,15 +83,15 @@ class VolumeControlContent_ extends React.PureComponent
     }
 }
 
-VolumeControlContent_.propTypes = {
+VolumeControl_.propTypes = {
     onAfterMuteClick: PropTypes.func,
 };
 
-VolumeControlContent_.contextType = ServiceContext;
+VolumeControl_.contextType = ServiceContext;
 
-const VolumeControlContent = ModelBinding(VolumeControlContent_, { playerModel: 'change' });
+export const VolumeControl = ModelBinding(VolumeControl_, { playerModel: 'change' });
 
-class VolumeControl extends React.PureComponent
+class VolumeControlButton_ extends React.PureComponent
 {
     constructor(props, context)
     {
@@ -106,11 +105,8 @@ class VolumeControl extends React.PureComponent
 
     getStateFromModel()
     {
-        const { playerModel, settingsModel } = this.context;
-
         return {
-            isMuted: playerModel.volume.isMuted,
-            displayInline: settingsModel.mediaSizeUp(MediaSize.medium),
+            isMuted: this.context.playerModel.volume.isMuted,
         };
     }
 
@@ -126,36 +122,22 @@ class VolumeControl extends React.PureComponent
 
     render()
     {
-        const { playerModel } = this.context;
-        const { isMuted, panelOpen, displayInline } = this.state;
-
-        if (displayInline)
-        {
-            return <VolumeControlContent />;
-        }
+        const { isMuted, panelOpen } = this.state;
 
         return (
-            <div className='button-bar`'>
-                <DropdownButton
-                    title='Show volume panel'
-                    iconName={volumeIcon(isMuted)}
-                    hideOnContentClick={false}
-                    direction='center'
-                    isOpen={panelOpen}
-                    onRequestOpen={this.handlePanelRequestOpen}>
-                    <VolumeControlContent
-                        playerModel={playerModel}
-                        onAfterMuteClick={this.handleMuteClick}/>
-                </DropdownButton>
-            </div>
+            <DropdownButton
+                title='Show volume control'
+                iconName={volumeIcon(isMuted)}
+                hideOnContentClick={false}
+                direction='left'
+                isOpen={panelOpen}
+                onRequestOpen={this.handlePanelRequestOpen}>
+                <VolumeControl onAfterMuteClick={this.handleMuteClick} />
+            </DropdownButton>
         );
     }
 }
 
-VolumeControl.propTypes = {};
-VolumeControl.contextType = ServiceContext;
+VolumeControlButton_.contextType = ServiceContext;
 
-export default ModelBinding(VolumeControl, {
-    playerModel: 'change',
-    settingsModel: 'mediaSizeChange'
-});
+export const VolumeControlButton = ModelBinding(VolumeControlButton_, { playerModel: 'change' });


### PR DESCRIPTION
- Adjust screen size breakpoints (approximately 640px for medium size and 960px for large size)
- Convert view switcher to menu on small size screens
- Display album column by default on medium size screens

Fixes #111
