### PR TITLE
fix various issues with API docs

### DIFF
--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -110,12 +110,12 @@ paths:
       - player
       summary: Play next item in currently played playlist
       operationId: playNext
-      parameters:
-      - name: by
-        in: query
-        description: Expression to select next item by (e.g. %artist%).
-        schema:
-          type: string
+      requestBody:
+        description: Additional request parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeActiveItemRequest'
       responses:
         204:
           description: Success
@@ -126,12 +126,12 @@ paths:
       - player
       summary: Play previous item in currently played playlist
       operationId: playPrevious
-      parameters:
-      - name: by
-        in: query
-        description: Expression to select previous item by (e.g. %artist%).
-        schema:
-          type: string
+      requestBody:
+        description: Additional request parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeActiveItemRequest'
       responses:
         204:
           description: Success
@@ -913,6 +913,12 @@ components:
       properties:
         player:
           $ref: '#/components/schemas/PlayerState'
+    ChangeActiveItemRequest:
+      type: object
+      properties:
+        by:
+          type: string
+          description: Expression to select next item by (e.g. %artist%)
     SetPlayerStateRequest:
       type: object
       properties:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -1209,6 +1209,12 @@ components:
           $ref: '#/components/schemas/PlayQueueItemsResult'
         outputs:
           $ref: '#/components/schemas/OutputsInfo'
+    FileSystemEntryType:
+      type: string
+      description: File system entry type (directory or file)
+      enum:
+      - D
+      - F
     FileSystemEntry:
       type: object
       properties:
@@ -1219,11 +1225,7 @@ components:
           type: string
           description: Full file path
         type:
-          type: string
-          description: File type
-          enum:
-          - D
-          - F
+          $ref: '#/components/schemas/FileSystemEntryType'
         size:
           type: integer
           description: File size in bytes
@@ -1250,4 +1252,3 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileSystemEntry'
-

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -1095,11 +1095,9 @@ components:
         plref:
           type: string
           description: Id or index of playlist which contains item to be added to queue
-          required: true
         itemIndex:
           type: number
           description: Item index in the specified playlist
-          required: true
         queueIndex:
           type: number
           description: Queue index to insert at (currently only supported by DeaDBeeF)
@@ -1180,7 +1178,6 @@ components:
         deviceId:
           type: string
           description: Output device id
-          required: true
     FileSystemEntry:
       type: object
       properties:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -83,7 +83,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       - name: index
         in: path
         description: Item index
@@ -293,7 +293,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       responses:
         204:
           description: Success
@@ -310,7 +310,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       - name: index
         in: path
         description: Target position. Use negative value to move to the last position
@@ -333,7 +333,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       - name: range
         in: path
         description: Playlist item range in form offset:count
@@ -369,7 +369,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       responses:
         200:
           description: Success
@@ -412,7 +412,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       responses:
         204:
           description: Success
@@ -429,7 +429,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       requestBody:
         description: Items to add
         content:
@@ -456,7 +456,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       requestBody:
         description: Copy items request
         content:
@@ -480,13 +480,13 @@ paths:
         description: Source playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       - name: targetId
         in: path
         description: Target playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       requestBody:
         description: Copy items request
         content:
@@ -510,7 +510,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       requestBody:
         description: Move items request
         content:
@@ -534,13 +534,13 @@ paths:
         description: Source playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       - name: targetId
         in: path
         description: Target playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       requestBody:
         description: Move items request
         content:
@@ -564,7 +564,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       requestBody:
         description: Indexes of items to remove
         content:
@@ -588,7 +588,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       requestBody:
         description: Sort parameters
         content:
@@ -677,7 +677,7 @@ paths:
         in: query
         description: Playlist id or index to return items from
         schema:
-          type: string
+          type: string | number
       - name: plrange
         in: query
         description: Playlist range to return items from
@@ -761,7 +761,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string
+          type: string | number
       - name: index
         in: path
         description: Item index
@@ -1080,7 +1080,7 @@ components:
       type: object
       properties:
         plref:
-          type: string
+          type: string | number
           description: Id or index of playlist which contains item to be removed from queue
         itemIndex:
           type: number

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -454,18 +454,12 @@ paths:
         required: true
         schema:
           type: string
-      - name: targetIndex
-        in: query
-        description: Position to copy items to. Items are copied to the end of the
-          playlist by default
-        schema:
-          type: number
       requestBody:
-        description: Indexes of items to copy
+        description: Copy items request
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ItemIndexesRequest'
+              $ref: '#/components/schemas/TransferPlaylistItemsRequest'
         required: true
       responses:
         204:
@@ -490,18 +484,12 @@ paths:
         required: true
         schema:
           type: string
-      - name: targetIndex
-        in: query
-        description: Playlist position to copy items to. Items are copied to the end
-          of the playlist by default
-        schema:
-          type: number
       requestBody:
-        description: Indexes of items to copy
+        description: Copy items request
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ItemIndexesRequest'
+              $ref: '#/components/schemas/TransferPlaylistItemsRequest'
         required: true
       responses:
         204:
@@ -520,18 +508,12 @@ paths:
         required: true
         schema:
           type: string
-      - name: targetIndex
-        in: query
-        description: Position to move items to. Items are moved to the end of the
-          playlist by default
-        schema:
-          type: number
       requestBody:
-        description: Indexes of items to move
+        description: Move items request
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ItemIndexesRequest'
+              $ref: '#/components/schemas/TransferPlaylistItemsRequest'
         required: true
       responses:
         204:
@@ -556,18 +538,12 @@ paths:
         required: true
         schema:
           type: string
-      - name: targetIndex
-        in: query
-        description: Position to move items to. Items are moved to the end of the
-          playlist by default
-        schema:
-          type: number
       requestBody:
-        description: Indexes of items to move
+        description: Move items request
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ItemIndexesRequest'
+              $ref: '#/components/schemas/TransferPlaylistItemsRequest'
         required: true
       responses:
         204:
@@ -591,7 +567,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ItemIndexesRequest'
+              $ref: '#/components/schemas/RemovePlaylistItemsRequest'
         required: true
       responses:
         204:
@@ -610,21 +586,12 @@ paths:
         required: true
         schema:
           type: string
-      - name: by
-        in: query
-        description: Expression to sort by (e.g. %title%)
-        schema:
-          type: string
-      - name: desc
-        in: query
-        description: Sort in descending order
-        schema:
-          type: boolean
-      - name: random
-        in: query
-        description: Sort randomly
-        schema:
-          type: boolean
+      requestBody:
+        description: Sort parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SortPlaylistItemsRequest'
       responses:
         204:
           description: Success
@@ -1054,7 +1021,7 @@ components:
           description: Items to add (files, directories, URLs)
           items:
             type: string
-    ItemIndexesRequest:
+    TransferPlaylistItemsRequest:
       type: object
       required: [items]
       properties:
@@ -1062,6 +1029,19 @@ components:
           type: array
           items:
             type: number
+          description: Item indices to process
+        targetIndex:
+          type: number
+          description: Position to add items at. By default items are added at the end of the playlist
+    RemovePlaylistItemsRequest:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            type: number
+          description: item indices to process
     AddToPlayQueueRequest:
       type: object
       required: [plref, itemIndex]
@@ -1108,6 +1088,18 @@ components:
       properties:
         playQueue:
           $ref: '#/components/schemas/PlayQueueItemsResult'
+    SortPlaylistItemsRequest:
+      type: object
+      properties:
+        by:
+          type: string
+          description: Expression to sort by (e.g. %title%)
+        desc:
+          type: boolean
+          description: Sort in descending order
+        random:
+          type: boolean
+          description: Sort randomly
     OutputDeviceInfo:
       type: object
       properties:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -277,22 +277,20 @@ paths:
       - playlists
       summary: Add playlist
       operationId: addPlaylist
-      parameters:
-      - name: index
-        in: query
-        description: Position to add playlist at. By default playlist is added to
-          the last position
-        schema:
-          type: number
-      - name: title
-        in: query
-        description: New playlist title
-        schema:
-          type: string
+      requestBody:
+        description: Request to add playlist
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddPlaylistRequest'
       responses:
-        204:
+        200:
           description: Success
-          content: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaylistItemInfo'
+      x-codegen-request-body-name: request
   /playlists/remove/{playlistId}:
     post:
       tags:
@@ -1052,6 +1050,18 @@ components:
               value:
                 type: number
                 description: New option value
+    AddPlaylistRequest:
+      type: object
+      properties:
+        index:
+          type: number
+          description: Position to add playlist at. By default playlist is added to the last position
+        title:
+          type: string
+          description: New playlist title
+        setCurrent:
+          type: boolean
+          description: Select playlist after creation
     AddItemsRequest:
       type: object
       properties:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -926,28 +926,30 @@ components:
       enum:
       - db
       - linear
+    ActiveItemInfo:
+      type: object
+      properties:
+        playlistId:
+          type: string
+        playlistIndex:
+          type: number
+        index:
+          type: number
+        position:
+          type: number
+        duration:
+          type: number
+        columns:
+          type: array
+          items:
+            type: string
     PlayerState:
       type: object
       properties:
         info:
           $ref: '#/components/schemas/PlayerInfo'
         activeItem:
-          type: object
-          properties:
-            playlistId:
-              type: string
-            playlistIndex:
-              type: number
-            index:
-              type: number
-            position:
-              type: number
-            duration:
-              type: number
-            columns:
-              type: array
-              items:
-                type: string
+          $ref: '#/components/schemas/ActiveItemInfo'
         playbackState:
           $ref: '#/components/schemas/PlaybackState'
         playbackMode:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -767,7 +767,7 @@ paths:
         description: Playlist item index
         required: true
         schema:
-          type: number
+          type: integer
       responses:
         200:
           description: Success
@@ -867,9 +867,9 @@ components:
         playlistId:
           type: string
         playlistIndex:
-          type: number
+          type: integer
         index:
-          type: number
+          type: integer
         position:
           type: number
         duration:
@@ -899,7 +899,7 @@ components:
         playbackState:
           $ref: '#/components/schemas/PlaybackState'
         playbackMode:
-          type: number
+          type: integer
           deprecated: true
         playbackModes:
           type: array
@@ -935,7 +935,7 @@ components:
           type: number
           description: New relative playback position (seconds)
         playbackMode:
-          type: number
+          type: integer
           description: New playback mode index
           deprecated: true
         options:
@@ -948,7 +948,7 @@ components:
                 type: string
                 description: Option identifier
               value:
-                type: number
+                type: integer | boolean
                 description: New option value
     PlaylistInfo:
       type: object
@@ -956,13 +956,13 @@ components:
         id:
           type: string
         index:
-          type: number
+          type: integer
         title:
           type: string
         isCurrent:
           type: boolean
         itemCount:
-          type: number
+          type: integer
         totalTime:
           type: number
     PlaylistsResult:
@@ -980,9 +980,9 @@ components:
       type: object
       properties:
         offset:
-          type: number
+          type: integer
         totalCount:
-          type: number
+          type: integer
         items:
           type: array
           items:
@@ -1013,7 +1013,7 @@ components:
       type: object
       properties:
         index:
-          type: number
+          type: integer
           description: Position to add playlist at. By default playlist is added to the last position
         title:
           type: string
@@ -1026,7 +1026,7 @@ components:
       required: [items]
       properties:
         index:
-          type: number
+          type: integer
           description: Position to add items at
         async:
           type: boolean
@@ -1049,10 +1049,10 @@ components:
         items:
           type: array
           items:
-            type: number
+            type: integer
           description: Item indices to process
         targetIndex:
-          type: number
+          type: integer
           description: Position to add items at. By default items are added at the end of the playlist
     RemovePlaylistItemsRequest:
       type: object
@@ -1061,8 +1061,8 @@ components:
         items:
           type: array
           items:
-            type: number
-          description: item indices to process
+            type: integer
+          description: Item indices to remove
     AddToPlayQueueRequest:
       type: object
       required: [plref, itemIndex]
@@ -1071,10 +1071,10 @@ components:
           type: string | number
           description: Id or index of playlist which contains item to be added to queue
         itemIndex:
-          type: number
+          type: integer
           description: Item index in the specified playlist
         queueIndex:
-          type: number
+          type: integer
           description: Queue index to insert at (currently only supported by DeaDBeeF)
     RemoveFromPlayQueueRequest:
       type: object
@@ -1083,10 +1083,10 @@ components:
           type: string | number
           description: Id or index of playlist which contains item to be removed from queue
         itemIndex:
-          type: number
+          type: integer
           description: Item index in the specified playlist
         queueIndex:
-          type: number
+          type: integer
           description: Play queue item index to remove
     PlayQueueItemInfo:
       type: object
@@ -1095,7 +1095,7 @@ components:
           type: string
           description: Playlist id
         playlistIndex:
-          type: number
+          type: integer
           description: Playlist index
         itemIndex:
           type: integer
@@ -1205,10 +1205,10 @@ components:
           - D
           - F
         size:
-          type: number
+          type: integer
           description: File size in bytes
         timestamp:
-          type: number
+          type: integer
           description: File timestamp (seconds since Unix epoch)
     FileSystemRootsResponse:
       type: object

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -435,7 +435,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AddItemsRequest'
+              $ref: '#/components/schemas/AddPlaylistItemsRequest'
         required: true
       responses:
         202:
@@ -1034,7 +1034,7 @@ components:
         setCurrent:
           type: boolean
           description: Select playlist after creation
-    AddItemsRequest:
+    AddPlaylistItemsRequest:
       type: object
       required: [items]
       properties:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -7,10 +7,10 @@ servers:
 tags:
 - name: player
   description: Player APIs
-- name: playqueue
-  description: Playback queue APIs
 - name: playlists
   description: Playlist APIs
+- name: playqueue
+  description: Playback queue APIs
 - name: outputs
   description: Output configuration APIs
 - name: query
@@ -44,10 +44,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  player:
-                    $ref: '#/components/schemas/PlayerState'
+                $ref: '#/components/schemas/GetPlayerStateResponse'
     post:
       tags:
       - player
@@ -192,10 +189,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  playQueue:
-                    $ref: '#/components/schemas/PlayQueueItemsResult'
+                $ref: '#/components/schemas/GetPlayQueueResponse'
   /playqueue/add:
     post:
       tags:
@@ -252,10 +246,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  playlists:
-                    $ref: '#/components/schemas/PlaylistsResult'
+               $ref: '#/components/schemas/GetPlaylistsResponse'
     post:
       tags:
       - playlists
@@ -366,10 +357,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  playlistItems:
-                    $ref: '#/components/schemas/PlaylistItemsResult'
+                $ref: '#/components/schemas/GetPlaylistItemsResponse'
   /playlists/{playlistId}:
     get:
       tags:
@@ -661,10 +649,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  outputs:
-                    $ref: '#/components/schemas/OutputsInfo'
+                $ref: '#/components/schemas/GetOutputsResponse'
   /outputs/active:
     post:
       tags:
@@ -756,18 +741,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  player:
-                    $ref: '#/components/schemas/PlayerState'
-                  playlists:
-                    $ref: '#/components/schemas/PlaylistsResult'
-                  playlistItems:
-                    $ref: '#/components/schemas/PlaylistItemsResult'
-                  playQueue:
-                    $ref: '#/components/schemas/PlayQueueItemsResult'
-                  outputs:
-                    $ref: '#/components/schemas/OutputsInfo'
+                $ref: '#/components/schemas/QueryResponse'
   /browser/roots:
     get:
       tags:
@@ -780,20 +754,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  pathSeparator:
-                    type: string
-                  roots:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/FileSystemEntry'
+                $ref: '#/components/schemas/FileSystemRootsResponse'
   /browser/entries:
     get:
       tags:
       - browser
       summary: Get file system entries
-      operationId: getFsEntries
+      operationId: getFileSystemEntries
       parameters:
       - name: path
         in: query
@@ -806,14 +773,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  pathSeparator:
-                    type: string
-                  entries:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/FileSystemEntry'
+                $ref: '#/components/schemas/FileSystemEntriesResponse'
   /artwork/current:
     get:
       tags:
@@ -926,6 +886,19 @@ components:
       enum:
       - db
       - linear
+    VolumeInfo:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/VolumeType'
+        min:
+          type: number
+        max:
+          type: number
+        value:
+          type: number
+        isMuted:
+          type: boolean
     ActiveItemInfo:
       type: object
       properties:
@@ -943,6 +916,17 @@ components:
           type: array
           items:
             type: string
+    PlayerInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        title:
+          type: string
+        version:
+          type: string
+        pluginVersion:
+          type: string
     PlayerState:
       type: object
       properties:
@@ -961,29 +945,43 @@ components:
             type: string
           deprecated: true
         volume:
-          type: object
-          properties:
-            type:
-              $ref: '#/components/schemas/VolumeType'
-            min:
-              type: number
-            max:
-              type: number
-            value:
-              type: number
-            isMuted:
-              type: boolean
-    PlayerInfo:
+          $ref: '#/components/schemas/VolumeInfo'
+    GetPlayerStateResponse:
       type: object
       properties:
-        name:
-          type: string
-        title:
-          type: string
-        version:
-          type: string
-        pluginVersion:
-          type: string
+        player:
+          $ref: '#/components/schemas/PlayerState'
+    SetPlayerStateRequest:
+      type: object
+      properties:
+        volume:
+          type: number
+          description: New volume value
+        isMuted:
+          type: boolean
+          description: New mute state
+        position:
+          type: number
+          description: New absolute playback position (seconds)
+        relativePosition:
+          type: number
+          description: New relative playback position (seconds)
+        playbackMode:
+          type: number
+          description: New playback mode index
+          deprecated: true
+        options:
+          type: array
+          description: Options to modify
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Option identifier
+              value:
+                type: number
+                description: New option value
     PlaylistInfo:
       type: object
       properties:
@@ -1021,37 +1019,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PlaylistItemInfo'
-    SetPlayerStateRequest:
+    GetPlaylistsResponse:
       type: object
       properties:
-        volume:
-          type: number
-          description: New volume value
-        isMuted:
-          type: boolean
-          description: New mute state
-        position:
-          type: number
-          description: New absolute playback position (seconds)
-        relativePosition:
-          type: number
-          description: New relative playback position (seconds)
-        playbackMode:
-          type: number
-          description: New playback mode index
-          deprecated: true
-        options:
-          type: array
-          description: Options to modify
-          items:
-            type: object
-            properties:
-              id:
-                type: string
-                description: Option identifier
-              value:
-                type: number
-                description: New option value
+        playlists:
+          $ref: '#/components/schemas/PlaylistsResult'
+    GetPlaylistItemsResponse:
+      type: object
+      properties:
+        playlistItems:
+          $ref: '#/components/schemas/PlaylistItemsResult'
     AddPlaylistRequest:
       type: object
       properties:
@@ -1131,6 +1108,11 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/PlayQueueItemInfo'
+    GetPlayQueueResponse:
+      type: object
+      properties:
+        playQueue:
+          $ref: '#/components/schemas/PlayQueueItemsResult'
     OutputDeviceInfo:
       type: object
       properties:
@@ -1180,6 +1162,24 @@ components:
         deviceId:
           type: string
           description: Output device id
+    GetOutputsResponse:
+      type: object
+      properties:
+        outputs:
+          $ref: '#/components/schemas/OutputsInfo'
+    QueryResponse:
+      type: object
+      properties:
+        player:
+          $ref: '#/components/schemas/PlayerState'
+        playlists:
+          $ref: '#/components/schemas/PlaylistsResult'
+        playlistItems:
+          $ref: '#/components/schemas/PlaylistItemsResult'
+        playQueue:
+          $ref: '#/components/schemas/PlayQueueItemsResult'
+        outputs:
+          $ref: '#/components/schemas/OutputsInfo'
     FileSystemEntry:
       type: object
       properties:
@@ -1201,3 +1201,22 @@ components:
         timestamp:
           type: number
           description: File timestamp (seconds since Unix epoch)
+    FileSystemRootsResponse:
+      type: object
+      properties:
+        pathSeparator:
+          type: string
+        roots:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileSystemEntry'
+    FileSystemEntriesResponse:
+      type: object
+      properties:
+        pathSeparator:
+          type: string
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileSystemEntry'
+

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -61,7 +61,6 @@ paths:
         204:
           description: Success
           content: {}
-      x-codegen-request-body-name: request
   /player/play:
     post:
       tags:
@@ -281,7 +280,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PlaylistInfo'
-      x-codegen-request-body-name: request
   /playlists/remove/{playlistId}:
     post:
       tags:
@@ -443,7 +441,6 @@ paths:
         204:
           description: Success
           content: {}
-      x-codegen-request-body-name: request
   /playlists/{playlistId}/items/copy:
     post:
       tags:
@@ -474,7 +471,6 @@ paths:
         204:
           description: Success
           content: {}
-      x-codegen-request-body-name: request
   /playlists/{sourceId}/{targetId}/items/copy:
     post:
       tags:
@@ -511,7 +507,6 @@ paths:
         204:
           description: Success
           content: {}
-      x-codegen-request-body-name: request
   /playlists/{playlistId}/items/move:
     post:
       tags:
@@ -542,7 +537,6 @@ paths:
         204:
           description: Success
           content: {}
-      x-codegen-request-body-name: request
   /playlists/{sourceId}/{targetId}/items/move:
     post:
       tags:
@@ -579,7 +573,6 @@ paths:
         204:
           description: Success
           content: {}
-      x-codegen-request-body-name: request
   /playlists/{playlistId}/items/remove:
     post:
       tags:
@@ -604,7 +597,6 @@ paths:
         204:
           description: Success
           content: {}
-      x-codegen-request-body-name: request
   /playlists/{playlistId}/items/sort:
     post:
       tags:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -83,7 +83,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       - name: index
         in: path
         description: Item index
@@ -293,7 +293,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       responses:
         204:
           description: Success
@@ -310,7 +310,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       - name: index
         in: path
         description: Target position. Use negative value to move to the last position
@@ -333,7 +333,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       - name: range
         in: path
         description: Playlist item range in form offset:count
@@ -369,7 +369,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       responses:
         200:
           description: Success
@@ -412,7 +412,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       responses:
         204:
           description: Success
@@ -429,7 +429,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       requestBody:
         description: Items to add
         content:
@@ -456,7 +456,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       requestBody:
         description: Copy items request
         content:
@@ -480,13 +480,13 @@ paths:
         description: Source playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       - name: targetId
         in: path
         description: Target playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       requestBody:
         description: Copy items request
         content:
@@ -510,7 +510,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       requestBody:
         description: Move items request
         content:
@@ -534,13 +534,13 @@ paths:
         description: Source playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       - name: targetId
         in: path
         description: Target playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       requestBody:
         description: Move items request
         content:
@@ -564,7 +564,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       requestBody:
         description: Indexes of items to remove
         content:
@@ -588,7 +588,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       requestBody:
         description: Sort parameters
         content:
@@ -677,7 +677,7 @@ paths:
         in: query
         description: Playlist id or index to return items from
         schema:
-          type: string | number
+          type: string | integer
       - name: plrange
         in: query
         description: Playlist range to return items from
@@ -761,7 +761,7 @@ paths:
         description: Playlist id or index
         required: true
         schema:
-          type: string | number
+          type: string | integer
       - name: index
         in: path
         description: Playlist item index
@@ -1010,7 +1010,7 @@ components:
       type: object
       properties:
         current:
-          type: string | number
+          type: string | integer
           description: Playlist id or index to select
           nullable: true
     UpdatePlaylistRequest:
@@ -1083,7 +1083,7 @@ components:
       required: [plref, itemIndex]
       properties:
         plref:
-          type: string | number
+          type: string | integer
           description: Id or index of playlist which contains item to be added to queue
         itemIndex:
           type: integer
@@ -1096,7 +1096,7 @@ components:
       type: object
       properties:
         plref:
-          type: string | number
+          type: string | integer
           description: Id or index of playlist which contains item to be removed from queue
           nullable: true
         itemIndex:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -919,6 +919,7 @@ components:
         by:
           type: string
           description: Expression to select next item by (e.g. %artist%)
+          nullable: true
     SetOptionRequest:
       type: object
       properties:
@@ -934,24 +935,30 @@ components:
         volume:
           type: number
           description: New volume value
+          nullable: true
         isMuted:
           type: boolean
           description: New mute state
+          nullable: true
         position:
           type: number
           description: New absolute playback position (seconds)
+          nullable: true
         relativePosition:
           type: number
           description: New relative playback position (seconds)
+          nullable: true
         playbackMode:
           type: integer
           description: New playback mode index
           deprecated: true
+          nullable: true
         options:
           type: array
           description: Options to modify
           items:
             $ref: '#/components/schemas/SetOptionRequest'
+          nullable: true
     PlaylistInfo:
       type: object
       properties:
@@ -1005,21 +1012,25 @@ components:
         current:
           type: string | number
           description: Playlist id or index to select
+          nullable: true
     UpdatePlaylistRequest:
       type: object
       properties:
         title:
           type: string
           description: New playlist title
+          nullable: true
     AddPlaylistRequest:
       type: object
       properties:
         index:
           type: integer
           description: Position to add playlist at. By default playlist is added to the last position
+          nullable: true
         title:
           type: string
           description: New playlist title
+          nullable: true
         setCurrent:
           type: boolean
           description: Select playlist after creation
@@ -1030,6 +1041,7 @@ components:
         index:
           type: integer
           description: Position to add items at
+          nullable: true
         async:
           type: boolean
           description: Process request asynchronously
@@ -1055,6 +1067,7 @@ components:
           description: Item indices to process
         targetIndex:
           type: integer
+          nullable: true
           description: Position to add items at. By default items are added at the end of the playlist
     RemovePlaylistItemsRequest:
       type: object
@@ -1078,18 +1091,22 @@ components:
         queueIndex:
           type: integer
           description: Queue index to insert at (currently only supported by DeaDBeeF)
+          nullable: true
     RemoveFromPlayQueueRequest:
       type: object
       properties:
         plref:
           type: string | number
           description: Id or index of playlist which contains item to be removed from queue
+          nullable: true
         itemIndex:
           type: integer
           description: Item index in the specified playlist
+          nullable: true
         queueIndex:
           type: integer
           description: Play queue item index to remove
+          nullable: true
     PlayQueueItemInfo:
       type: object
       properties:
@@ -1169,7 +1186,8 @@ components:
       properties:
         typeId:
           type: string
-          description: Output type id. Omit if not changing output type
+          description: Output type id. If not specified current output type is preserved
+          nullable: true
         deviceId:
           type: string
           description: Output device id

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -1227,9 +1227,11 @@ components:
         size:
           type: integer
           description: File size in bytes
+          format: int64
         timestamp:
           type: integer
           description: File timestamp (seconds since Unix epoch)
+          format: int64
     FileSystemRootsResponse:
       type: object
       properties:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -1043,6 +1043,7 @@ components:
           description: Select playlist after creation
     AddItemsRequest:
       type: object
+      required: [items]
       properties:
         index:
           type: number
@@ -1063,6 +1064,7 @@ components:
             type: string
     ItemIndexesRequest:
       type: object
+      required: [items]
       properties:
         items:
           type: array
@@ -1070,6 +1072,7 @@ components:
             type: number
     AddToPlayQueueRequest:
       type: object
+      required: [plref, itemIndex]
       properties:
         plref:
           type: string
@@ -1155,6 +1158,7 @@ components:
             $ref: '#/components/schemas/OutputTypeInfo'
     SetOutputDeviceRequest:
       type: object
+      required: [deviceId]
       properties:
         typeId:
           type: string

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -1200,15 +1200,25 @@ components:
       type: object
       properties:
         player:
-          $ref: '#/components/schemas/PlayerState'
+          nullable: true
+          anyOf:
+          - $ref: '#/components/schemas/PlayerState'
         playlists:
-          $ref: '#/components/schemas/PlaylistsResult'
+          nullable: true
+          anyOf:
+          - $ref: '#/components/schemas/PlaylistsResult'
         playlistItems:
-          $ref: '#/components/schemas/PlaylistItemsResult'
+          nullable: true
+          anyOf:
+          - $ref: '#/components/schemas/PlaylistItemsResult'
         playQueue:
-          $ref: '#/components/schemas/PlayQueueItemsResult'
+          nullable: true
+          anyOf:
+          - $ref: '#/components/schemas/PlayQueueItemsResult'
         outputs:
-          $ref: '#/components/schemas/OutputsInfo'
+          nullable: true
+          anyOf:
+          - $ref: '#/components/schemas/OutputsInfo'
     FileSystemEntryType:
       type: string
       description: File system entry type (directory or file)

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -919,6 +919,15 @@ components:
         by:
           type: string
           description: Expression to select next item by (e.g. %artist%)
+    SetOptionRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Option identifier
+        value:
+          type: integer | boolean
+          description: New option value
     SetPlayerStateRequest:
       type: object
       properties:
@@ -942,14 +951,7 @@ components:
           type: array
           description: Options to modify
           items:
-            type: object
-            properties:
-              id:
-                type: string
-                description: Option identifier
-              value:
-                type: integer | boolean
-                description: New option value
+            $ref: '#/components/schemas/SetOptionRequest'
     PlaylistInfo:
       type: object
       properties:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -289,7 +289,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PlaylistItemInfo'
+                $ref: '#/components/schemas/PlaylistInfo'
       x-codegen-request-body-name: request
   /playlists/remove/{playlistId}:
     post:

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -251,12 +251,13 @@ paths:
       - playlists
       summary: Update playlist collection
       operationId: updatePlaylists
-      parameters:
-      - name: current
-        in: query
-        description: Playlist id or index to make current
-        schema:
-          type: string
+      requestBody:
+        description: Request to update playlists
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePlaylistsRequest'
+        required: true
       responses:
         204:
           description: Success
@@ -388,11 +389,13 @@ paths:
         required: true
         schema:
           type: string
-      - name: title
-        in: query
-        description: New playlist title
-        schema:
-          type: string
+      requestBody:
+        description: Request to update playlist
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePlaylistRequest'
+        required: true
       responses:
         204:
           description: Success
@@ -988,6 +991,18 @@ components:
       properties:
         playlistItems:
           $ref: '#/components/schemas/PlaylistItemsResult'
+    UpdatePlaylistsRequest:
+      type: object
+      properties:
+        current:
+          type: string | number
+          description: Playlist id or index to select
+    UpdatePlaylistRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          description: New playlist title
     AddPlaylistRequest:
       type: object
       properties:
@@ -1047,7 +1062,7 @@ components:
       required: [plref, itemIndex]
       properties:
         plref:
-          type: string
+          type: string | number
           description: Id or index of playlist which contains item to be added to queue
         itemIndex:
           type: number

--- a/docs/player-api.yml
+++ b/docs/player-api.yml
@@ -764,10 +764,10 @@ paths:
           type: string | number
       - name: index
         in: path
-        description: Item index
+        description: Playlist item index
         required: true
         schema:
-          type: string
+          type: number
       responses:
         200:
           description: Success


### PR DESCRIPTION
- Provide `nullable` and `required` where needed
- Use `integer` for indices
- Move all `POST` parameters to request body
- Introduce all necessary named types
- Correctly document playlist refs as having `string | integer` type
- Correctly document `/api/playlists/add`